### PR TITLE
fix unicode decoding bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ class ScrollWidget(gtk.DrawingArea):
         heights = list()
         bearings = list()
         corrected_text = []
-        for i, bit in enumerate(self.text):
+        for i, bit in enumerate(x.decode('utf-8') for x in self.text):
             c.set_font_size(SIZES[i])
             first_try = True
             ellipsis = u'\u2026'


### PR DESCRIPTION
Previously, pynijmegen crashed when it occurred that the byte
preceeding the ellipsis (`\u2026`) occurred directly after another
multi-byte character, because `enumerate` works _per byte_, instead
of per character.

This pull request changes the to-be-drawed strings to be encoded to
unicode strings before being drawn.
